### PR TITLE
Add gitignore and contributing guidelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+# General ignores
+*.swp
+*~
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+logs/
+
+# Python
+__pycache__/
+*.py[cod]
+
+# Node
+node_modules/
+.npm/
+
+# Compiled binaries
+*.o
+*.a
+*.so
+*.dll
+*.dylib
+*.out
+*.elf
+*.hex
+
+# Build directories
+build/
+dist/
+
+# IDEs and Editors
+.vscode/
+.idea/
+
+# Raspberry Pi
+.env
+
+# Nextcloud
+config/config.php
+data/
+nextcloud.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+Thank you for your interest in contributing! You can help by reporting bugs and submitting pull requests.
+
+## Issues
+- Search the issue tracker to avoid duplicates.
+- Open a new issue with a clear description of the problem or suggestion.
+
+## Pull Requests
+- Fork the repository and create a feature branch.
+- Make your changes with clear commit messages.
+- Ensure your branch is up to date with the latest `main` branch.
+- Open a pull request describing your changes and reference any related issues.
+
+We appreciate your contributions!


### PR DESCRIPTION
## Summary
- add `.gitignore` for Raspberry Pi/Nextcloud development, ignoring logs and compiled artifacts
- add `CONTRIBUTING.md` with basic contribution instructions

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6842a99deb14832da111ecc788fe9cad