### PR TITLE
Add checks for shellcheck and yamllint

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ chmod +x start
 
 Currently the script is empty; modify it to fit your own deployment workflow (for example, to pull images and launch containers with Docker Compose).
 
+## Development dependencies
+
+The `scripts/run_tests.sh` helper relies on `shellcheck` and `yamllint` for linting.
+Install them via your package manager, for example:
+
+```bash
+sudo apt-get install shellcheck yamllint
+```
+
 ## License
 
 This project is released under the [MIT License](LICENSE).

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 set -euo pipefail
 
+# Ensure required tools are available
+if ! command -v shellcheck >/dev/null; then
+  echo "shellcheck is required but not installed." >&2
+  exit 1
+fi
+
+if ! command -v yamllint >/dev/null; then
+  echo "yamllint is required but not installed." >&2
+  exit 1
+fi
+
 echo "Running ShellCheck..."
 sh_files=$(git ls-files '*.sh')
 if [ -n "$sh_files" ]; then


### PR DESCRIPTION
## Summary
- ensure scripts/run_tests.sh verifies shellcheck and yamllint are installed before running
- document development tools in README

## Testing
- `bash scripts/run_tests.sh` *(fails: shellcheck is required but not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842ad9c2a9c832da04c68ff84eda698