### PR TITLE
Add docker start script and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,22 @@ The guide also covers optional topics such as log rotation, resource limits for 
 
 ## Using the `start` script
 
-The repository includes an executable `start` script. Run it to automate any
-custom tasks you add:
+The repository includes an executable `start` script that launches the Docker
+Compose stack. Run it with:
 
 ```bash
 ./start
 ```
 
-By default the script only prints a reminder that you should replace the
-placeholder with your own Docker Compose commands.
+The script checks that `docker` and `docker compose` (or `docker-compose`) are
+available and prints a helpful error if they are missing. When the requirements
+are met it executes:
+
+```bash
+docker compose up -d
+```
+
+You can extend the script with additional tasks as needed.
 
 ## Development dependencies
 

--- a/start
+++ b/start
@@ -1,6 +1,23 @@
 #!/bin/bash
 # Helper script to start the Nextcloud stack
+set -euo pipefail
 
-echo "Placeholder: add your Docker Compose commands here"
-# For example:
-# docker compose up -d
+# Ensure Docker is available
+if ! command -v docker >/dev/null; then
+  echo "Docker is required but not installed." >&2
+  exit 1
+fi
+
+# Determine which Docker Compose command to use
+if docker compose version >/dev/null 2>&1; then
+  compose_cmd="docker compose"
+elif command -v docker-compose >/dev/null; then
+  compose_cmd="docker-compose"
+else
+  echo "Docker Compose is required but not installed." >&2
+  echo "Install Docker Compose v2 (docker compose) or docker-compose." >&2
+  exit 1
+fi
+
+echo "Starting containers..."
+$compose_cmd up -d


### PR DESCRIPTION
## Summary
- update `start` script to run the compose stack
- add checks for Docker and Docker Compose
- document the new behaviour in the README

## Testing
- `./scripts/run_tests.sh` *(fails: `shellcheck` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842afca2d40832da3ea399e51812ab6