### PR TITLE
Add docker-compose stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,37 +27,8 @@ docker compose version
    ```bash
    docker network create -d bridge nextcloud_net
    ```
-2. **Database container** – run MariaDB with some InnoDB tuning. Mount a folder (or volume) for `/var/lib/mysql` and add a custom configuration file e.g.:
-   ```ini
-   # mariadb-conf.d/99-nextcloud.cnf
-   [mysqld]
-   innodb_buffer_pool_size = 1024M
-   innodb_flush_method = O_DIRECT
-   innodb_flush_log_at_trx_commit = 2
-   innodb_log_file_size = 256M
-   ```
-3. **Redis container** for caching and file locking:
-   ```bash
-   docker run -d --name nextcloud_redis --network nextcloud_net \
-      redis:7-alpine redis-server --appendonly no
-   ```
-4. **Nextcloud container** using the official Apache image. Connect it to `nextcloud_net` and supply the database credentials and trusted domain environment variables. Example compose snippet:
-   ```yaml
-   nextcloud:
-     image: nextcloud:27-apache
-     networks:
-       - nextcloud_net
-     environment:
-       - MYSQL_HOST=nextcloud_db
-       - MYSQL_DATABASE=nextcloud
-       - MYSQL_USER=nextcloud
-       - MYSQL_PASSWORD=<password>
-       - NEXTCLOUD_TRUSTED_DOMAINS=cloud.example.com
-     volumes:
-       - nextcloud_html:/var/www/html
-   ```
-5. **Nginx reverse proxy** – handle HTTPS for your domain and forward traffic to the Nextcloud container. Combine it with the official `certbot` image to obtain and renew Let's Encrypt certificates. Nginx serves the ACME challenge files from a shared volume and reloads when certificates are renewed.
-6. **Start the stack** via Docker Compose and browse to `https://cloud.example.com` to finish the initial Nextcloud installation.
+2. **Review `docker-compose.yml`** which defines services for Nextcloud (Apache), MariaDB, Redis and an optional Nginx reverse proxy. Adjust the passwords, domain names and volume locations to suit your environment.
+3. **Start the stack** with `./start` (or `docker compose -f docker-compose.yml up -d`) and browse to `https://cloud.example.com` to finish the installation.
 
 The guide also covers optional topics such as log rotation, resource limits for each container and using Btrfs snapshots for quick backups and upgrades. See the comments in the configuration files for further pointers.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,63 @@
+version: "3.8"
+
+services:
+  db:
+    image: mariadb:10.11
+    restart: unless-stopped
+    networks:
+      - nextcloud
+    volumes:
+      - db:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: change-me
+      MYSQL_PASSWORD: nextcloud
+      MYSQL_DATABASE: nextcloud
+      MYSQL_USER: nextcloud
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    networks:
+      - nextcloud
+    command: redis-server --appendonly no
+
+  nextcloud:
+    image: nextcloud:27-apache
+    restart: unless-stopped
+    networks:
+      - nextcloud
+    depends_on:
+      - db
+      - redis
+    environment:
+      MYSQL_HOST: db
+      MYSQL_DATABASE: nextcloud
+      MYSQL_USER: nextcloud
+      MYSQL_PASSWORD: nextcloud
+      REDIS_HOST: redis
+      NEXTCLOUD_TRUSTED_DOMAINS: cloud.example.com
+    volumes:
+      - nextcloud_html:/var/www/html
+
+  # Uncomment the following service to run an Nginx reverse proxy in front of Nextcloud
+  # nginx:
+  #   image: nginx:alpine
+  #   restart: unless-stopped
+  #   networks:
+  #     - nextcloud
+  #   volumes:
+  #     - ./nginx.conf:/etc/nginx/nginx.conf:ro
+  #     - nextcloud_html:/var/www/html:ro
+  #   ports:
+  #     - "80:80"
+  #     - "443:443"
+  #   depends_on:
+  #     - nextcloud
+
+networks:
+  nextcloud:
+    external: true
+
+volumes:
+  db:
+  nextcloud_html:

--- a/start
+++ b/start
@@ -20,4 +20,4 @@ else
 fi
 
 echo "Starting containers..."
-$compose_cmd up -d
+$compose_cmd -f docker-compose.yml up -d


### PR DESCRIPTION
## Summary
- provide a docker-compose.yml defining Nextcloud, MariaDB, Redis and optional Nginx
- reference the compose setup in the README
- update `start` script to use the compose file

## Testing
- `./scripts/run_tests.sh` *(fails: shellcheck not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842b0710954832d8f01a7ee792d3010