### PR TITLE
Fix shellcheck invocation

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -13,9 +13,9 @@ if ! command -v yamllint >/dev/null; then
 fi
 
 echo "Running ShellCheck..."
-sh_files=$(git ls-files '*.sh')
-if [ -n "$sh_files" ]; then
-  shellcheck "$sh_files"
+mapfile -t sh_files < <(git ls-files '*.sh')
+if [ ${#sh_files[@]} -gt 0 ]; then
+  shellcheck "${sh_files[@]}"
 else
   echo "No shell scripts to check."
 fi


### PR DESCRIPTION
## Summary
- use an array to store `.sh` files before running ShellCheck

## Testing
- `bash scripts/run_tests.sh` *(fails: shellcheck not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842dfa9151c832db088655cc09678b0