### PR TITLE
Extend ShellCheck coverage

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -13,7 +13,7 @@ if ! command -v yamllint >/dev/null; then
 fi
 
 echo "Running ShellCheck..."
-mapfile -t sh_files < <(git ls-files '*.sh')
+mapfile -t sh_files < <(git ls-files '*.sh' start)
 if [ ${#sh_files[@]} -gt 0 ]; then
   shellcheck "${sh_files[@]}"
 else


### PR DESCRIPTION
## Summary
- expand `scripts/run_tests.sh` to lint the `start` helper script

## Testing
- `bash scripts/run_tests.sh` *(fails: shellcheck is required but not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842e1983500832dbf86619a2f85e01f